### PR TITLE
Update NuixCommandConsole.csproj

### DIFF
--- a/NuixCommandConsole.csproj
+++ b/NuixCommandConsole.csproj
@@ -216,18 +216,6 @@
     <None Include="ActivityTemplates\PSTPusherNode\PSTSearch.rb_">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="ActivityTemplates\PSTPusherNode\source data\output_5.pst">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ActivityTemplates\PSTPusherNode\source data\PSTs\Michael Lappin.pst">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ActivityTemplates\PSTPusherNode\source data\PSTs\Michael Lappin_1.pst">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ActivityTemplates\PSTPusherNode\source data\recipient.pst">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="ActivityTemplates\PSTPusherNode\SwingDialogs.rb_">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
removed directives to copy test pst files (outlook_5.pst, etc....).   Not a big deal, but might be annoying to other folks that check out the project.  Could not build on my dev box until I had removed these.